### PR TITLE
Latout only matches alphanumeric characters

### DIFF
--- a/AutoLayout/@Resources/ResolutionChecker.lua
+++ b/AutoLayout/@Resources/ResolutionChecker.lua
@@ -8,7 +8,7 @@ function Initialize()
 
    -- Convert LayoutMap string to table
    layoutMap = {}
-   for k, v in string.gmatch(layoutMapStr, "(%d+x%d+)=(%w+)" .. layoutMapDelimiter) do
+   for k, v in string.gmatch(layoutMapStr, "(%d+x%d+)=([^" .. layoutMapDelimiter .. "]+)") do
       layoutMap[k] = v
    end
 


### PR DESCRIPTION
Issue: The original `%w+` regex only matches alphanumeric characters for `layout`, which breaks when the `layout` contains spaces or special characters.

This PR changes this behavior to match all characters except the delimiter. Moreover, it also removes the necessity to put the delimiter at the end of `layoutMapStr`, without breaking the compatibility to current settings (tailing delimiter still works).